### PR TITLE
Rmoradc/feature/20 read status

### DIFF
--- a/jabMap/mind-map/src/App.js
+++ b/jabMap/mind-map/src/App.js
@@ -5,13 +5,11 @@ import React, {
 } from "react";
 import "./App.css";
 import MindMap from "./MindMap";
-import KonvaReferencesTable from "./KonvaReferencesTable";
 import {makeStyles} from "@material-ui/core/styles";
-import { Layer, Stage, Image } from 'react-konva';
+import { Layer, Stage } from 'react-konva';
 import useWindowDimensions from './WindowDimensions';
 import ToolBar from "./ToolBar";
 import NodeInfoPanel from "./NodeInfoPanel";
-import useImage from 'use-image';
 import ReferencesTable from "./ReferencesTable";
 
 
@@ -37,7 +35,6 @@ function App() {
         if(!linking){
             setSelectedNode(selected);
         } else {
-            // TODO make edge between clicked node and selected
             addEdge(selectedNode, selected);
             setLinking(false);
             setSelectedNode(selected);
@@ -192,7 +189,6 @@ function App() {
     useEffect(() => {
         fetchReferences();
         fetchMap();
-        console.log(selectedNode)
     }, []);
 
     const saveMap = () => {

--- a/jabMap/mind-map/src/Node.js
+++ b/jabMap/mind-map/src/Node.js
@@ -11,13 +11,24 @@ const Node = ({node, id, colors, updateEdges, setSelectedNode, selectedNodeId, u
       updateNode(node);
       updateEdges(node.id, e.target.x(), e.target.y());
     }
+    
+    const toggleReadIcon = () => {
+      if(node.icons){
+        let newIcons = [];
+        if(node.icons.includes("READ")){
+          newIcons = node.icons.filter((icon) => {return icon !== "READ"});
+          newIcons.push("TO_READ");
+        } else if (node.icons.includes("TO_READ")) {
+          newIcons = node.icons.filter((icon) => {return icon !== "TO_READ"});
+          newIcons.push("READ")
+        }
+        node.icons = newIcons;
+        updateNode(node);
+      }
 
-    const getIcons = () => {
-      
     }
 
     const [bookmark] = useImage('/assets/bookmarkSmall.png');
-
 
     const width = 150
     const height = 70
@@ -63,7 +74,8 @@ const Node = ({node, id, colors, updateEdges, setSelectedNode, selectedNodeId, u
               offsetX={width/2 -10}
               offsetY={-height/2 + 20}
           >
-              {node.citationKey && <Image image={bookmark}/>}
+              {(node.citationKey && node.icons && (node.icons.includes("TO_READ") || node.icons.includes("READ"))) && 
+                <Image id={`${node.id}_read_status`} image={bookmark} fill={node.icons.includes("READ") ? 'green' : selectedNodeId === node.id ? "#a2b8e5" : "white" } onClick={toggleReadIcon}/>}
           </Group>
       </Group>
     );

--- a/src/main/java/org/jabref/logic/jabmap/BibtexMindMapAdapter.java
+++ b/src/main/java/org/jabref/logic/jabmap/BibtexMindMapAdapter.java
@@ -83,6 +83,9 @@ public class BibtexMindMapAdapter extends Converter<List<BibEntry>, MindMap> {
                     if (node.getColour() != null) {
                         newEntry.setField(MindMapField.NODE_COLOUR, node.getColour());
                     }
+                    if (node.getIcons() != null ){
+                        newEntry.setField(MindMapField.NODE_ICONS, node.getIconsString());
+                    }
                     return newEntry;
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/org/jabref/model/jabmap/MindMapNode.java
+++ b/src/main/java/org/jabref/model/jabmap/MindMapNode.java
@@ -51,6 +51,13 @@ public class MindMapNode {
         return icons;
     }
 
+    public String getIconsString() {
+        String iconsString = icons.toString();
+        iconsString = iconsString.substring(iconsString.indexOf('[') + 1, iconsString.indexOf(']'));
+        iconsString = iconsString.replace(" ", "");
+        return iconsString;
+    }
+
     public float getX_pos() {
         return x_pos;
     }


### PR DESCRIPTION
<!-- 
Describe the changes you have made here: what, why, ... 
Link issues that are fixed, e.g. "Fixes #333".
If you fixed a koppor issue, link it, e.g. "Fixes https://github.com/koppor/jabref/issues/47".
The title of the PR must not reference an issue, because GitHub does not support autolinking there.
-->
Implements #20 

Toggleable read status icon for bibEntry nodes. Backend also updated to handle saving icon arrays.
<!-- 
- Go through the list below. If a task has been completed, mark it done by using `[x]`.
- Please don't remove any items, just leave them unchecked if they are not applicable.
-->

- [ ] Change in CHANGELOG.md described (if applicable)
- [ ] Tests created for changes (if applicable)
- [x] Manually tested changed features in running JabRef (always required)
- [x] Screenshots added in PR description (for UI changes)
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, submitted a pull request to the documentation repository.


![image](https://user-images.githubusercontent.com/43200280/95940801-c1aafd00-0e3b-11eb-9c9a-215747185e27.png)
